### PR TITLE
Just return false for non-object arguments.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
 /*global window*/
 
 /**
- * Module dependencies.
- */
-
-var assert = require('assert');
-
-/**
  * Check if object is dom node.
  *
  * @param {Object} val
@@ -15,7 +9,7 @@ var assert = require('assert');
  */
 
 module.exports = function isNode(val){
-  assert.equal(typeof val, 'object', 'is-dom: val should be an object');
+  if (typeof val !== 'object') return false;
   if ('object' == typeof window.Node) return val instanceof window.Node;
   return 'number' == typeof val.nodeType && 'string' == typeof val.nodeName;
 }

--- a/test.js
+++ b/test.js
@@ -21,13 +21,12 @@ beforeEach(function() {
  */
 
 describe('is-dom', function() {
-  it('should assert argument types', function() {
-    isDom.bind(null, 'foo')
-      .should.throw('is-dom: val should be an object');
-  });
-
-  it('should check if object is a dom node', function() {
+  it('should check if supplied argument is a dom node', function() {
+    isDom(2).should.equal(false)
+    isDom('foo').should.equal(false)
+    isDom(/asda/).should.equal(false)
     isDom({}).should.equal(false);
+    isDom({nodeType: 1, nodeName: 'BODY'}).should.equal(true)
     isDom(global.window).should.equal(false);
     isDom(global.document).should.equal(true);
   });


### PR DESCRIPTION
Found it surprising that this threw for non-object arguments.
