### PR TITLE
Avoid always duck-typing

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = isNode
 function isNode (val) {
   return (!val || typeof val !== 'object')
     ? false
-    : (typeof window === 'object' && typeof window.Node === 'object')
+    : (typeof window === 'object' && typeof window.Node === 'function')
       ? (val instanceof window.Node)
       : (typeof val.nodeType === 'number') &&
         (typeof val.nodeName === 'string')


### PR DESCRIPTION
Hello. Found this on npmjs.org and was thinking of using but didn't look right to me... `window.Node` is expected to be of type object which will never be true hence the `instanceof` expression was never being executed, relying in all cases on duck-typing. The expectation should have been function (as a constructor), not object.